### PR TITLE
GetRound updated, helper-methods added and 'end' emit-bug fixed

### DIFF
--- a/src/Entities/MolotovGrenade.js
+++ b/src/Entities/MolotovGrenade.js
@@ -2,8 +2,6 @@ const Grenade = require(__dirname + '/Grenade');
 
 class MolotovGrenade extends Grenade {
 
-	
-
 }
 
 module.exports = MolotovGrenade;

--- a/src/Entities/Player.js
+++ b/src/Entities/Player.js
@@ -87,7 +87,7 @@ class Player extends Entity {
 	}
 
 	hasHelmet() {
-		return this.getValue('m_bHasFelmet') == 1;
+		return this.getValue('m_bHasHelmet') == 1;
 	}
 
 	getCurrentEquipmentValue() {

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -63,6 +63,11 @@ class Demo extends EventEmitter {
 		while(this.running){
 
 			let command = this.stream.byte();
+			if (command === undefined){
+				this.running = false;
+				this.emit('end');
+			}
+
 			let tick = this.stream.int32();
 			this.tick = tick;
 			
@@ -128,6 +133,26 @@ class Demo extends EventEmitter {
 
 	getPlayers () {
 		return this.getEntities(EntitiesMap.Player);
+	}
+
+	getGrenades(){
+		return this.getEntities(EntitiesMap.Grenade);
+	}
+	
+	getFlashes(){
+		return this.getEntities(EntitiesMap.Flashbang);
+	}
+	
+	getMolotovs(){
+		return this.getEntities(EntitiesMap.MolotovGrenade);
+	}
+	
+	getHEGrenades(){
+		return this.getEntities(EntitiesMap.HEGrenade);
+	}
+	
+	getSmokeGrenades(){
+		return this.getEntities(EntitiesMap.SmokeGrenade);
 	}
 
 	getRound () {
@@ -623,7 +648,6 @@ class Demo extends EventEmitter {
 			}
 
 			switch(description.name){
-
 				case 'player_connect':
 					let player ={
 						'name': params.name,
@@ -644,12 +668,15 @@ class Demo extends EventEmitter {
 					break;
 
 				case 'round_start':
-					
-					this.match.round++;
+					this.match.round = 1;
+					this.getTeams().forEach(team =>{
+						
+						let team_number = team.getTeamNumber();
 
-					if(this.match.round === 0)
-						this.match.round++;
+						if(team_number)
+							this.match.round += team.getScore();
 
+					});
 					break;
 
 			}


### PR DESCRIPTION
Fixes for the player method "hasHelmet" which was incorrectly attempting to retrieve the wrong parameter.

Fixed an issue where the 'end' event was not emitted causing the parser to hang.

Added some helper-methods to more easily retrieve grenades while parsing demo through getGrenades, getFlashes, getHEGrenades, getSmokegrenades and getMolotovs.

Lastly updated the getRound() function to correctly count the round-number by checking teams' scores when round starts rather than incrementing by one since restarts of rounds can happen.